### PR TITLE
Use do-while instead of tail recursion

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,13 @@ module.exports = function(term) {
 
   function getCh() {
 
-    fs.readSync(fd, buf, 0, 1);
-    var ch = buf.toString();
-
-    if (ch == term) {
-      fs.closeSync(fd);
-    }
-    else {
-      str += ch;
-      getCh();
-    }
+    var ch;
+    do {
+        fs.readSync(fd, buf, 0, 1);
+        var ch = buf.toString();
+        str += ch == term?'':ch;
+    } while (ch != term);
+    fs.closeSync(fd);
   }
 
   getCh();


### PR DESCRIPTION
Since javascript doesn't do tail call elimination a recursive solution
still builds up a big pile of stack frames (one per character) each
containing a string (ch) that doesn't get garbage collected until the
whole thing has returned. It's trivial to replace tail recursion with a
do-while loop which doesn't suffer from the negative effects.
