### PR TITLE
Update Node.js version check to not assume 0.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ function prompt(option) {
       option.echo = '*';
   }
 
-  var fd = process.platform !== 'win32' && +process.version.substr(3) < 12 ? 
+  var nodeVersion = Number(/v(\d+\.\d+)/.exec(process.version)[1]);
+  var fd = process.platform !== 'win32' && nodeVersion < 0.12 ? 
     fs.openSync('/dev/tty', 'rs') : 
     process.stdin.fd;
     


### PR DESCRIPTION
Fixes a false positive with 4.x and 5.x

PR for #11