### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,7 +173,7 @@ function create(config) {
         }
       }
       
-      if (char == 127) { //backspace
+      if (char == 127 || (process.platform == 'win32' && char == 8)) { //backspace
         if (!insert) continue;
         str = str.slice(0, insert-1) + str.slice(insert);
         insert--;


### PR DESCRIPTION
On win32 the charcode for backspace is 8
Added an additional clause to the if statement on line 176 to check if the platform is windows and char is 8, this fixes a backspace problem on windows.