### PR TITLE
Does not error on non-TTYs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,27 +1,3 @@
-/**
- * The MIT License (MIT)
- *
- * Copyright (c) 2014 Salehen Shovon Rahman
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- **/
-
 'use strict';
 
 var fs = require('fs');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,31 @@
-'use strict'
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Salehen Shovon Rahman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ **/
+
+'use strict';
 
 var fs = require('fs');
-var term = 13; // carriage return
+var term = [13, 10]; //carriage return
 
 /**
  * create -- sync function for reading user input from stdin
@@ -10,207 +34,240 @@ var term = 13; // carriage return
  *   autocomplete: {StringArray} function({String})
  *   history: {String} a history control object (see `prompt-sync-history`)
  * }
- * @returns {Function} prompt function 
+ * @returns {Function} prompt function
  */
 
 function create(config) {
 
-  config = config || {};
-  var sigint = config.sigint;
-  var autocomplete = config.autocomplete = 
-    config.autocomplete || function(){return []};
-  var history = config.history;
-  prompt.history = history || {save: function(){}};
-  prompt.hide = function (ask) { return prompt(ask, {echo: ''}) };
+    config = config || {};
+    var sigint = config.sigint;
+    var autocomplete = config.autocomplete =
+        config.autocomplete || function() {
+            return []
+        };
+    var history = config.history;
+    prompt.history = history || {
+        save: function() {}
+    };
+    prompt.hide = function(ask) {
+        return prompt(ask, {
+            echo: ''
+        })
+    };
 
-  return prompt;
-
-
-  /**
-   * prompt -- sync function for reading user input from stdin
-   *  @param {String} ask opening question/statement to prompt for
-   *  @param {String} value initial value for the prompt
-   *  @param   {Object} opts {
-   *   echo: set to a character to be echoed, default is '*'. Use '' for no echo
-   *   value: {String} initial value for the prompt
-   *   ask: {String} opening question/statement to prompt for, does not override ask param
-   *   autocomplete: {StringArray} function({String})
-   * }
-   * 
-   * @returns {string} Returns the string input or (if sigint === false) 
-   *                   null if user terminates with a ^C  
-   */
+    return prompt;
 
 
-  function prompt(ask, value, opts) {
-    var insert = 0, savedinsert = 0, res, i, savedstr;
-    opts = opts || {};
+    /**
+     * prompt -- sync function for reading user input from stdin
+     *  @param {String} ask opening question/statement to prompt for
+     *  @param {String} value initial value for the prompt
+     *  @param   {Object} opts {
+     *   echo: set to a character to be echoed, default is '*'. Use '' for no echo
+     *   value: {String} initial value for the prompt
+     *   ask: {String} opening question/statement to prompt for, does not override ask param
+     *   autocomplete: {StringArray} function({String})
+     * }
+     *
+     * @returns {string} Returns the string input or (if sigint === false)
+     *                   null if user terminates with a ^C
+     */
 
-    if (Object(ask) === ask) {
-      opts = ask;
-      ask = opts.ask;
-    } else if (Object(value) === value) {
-      opts = value;
-      value = opts.value;
-    }
-    ask = ask || '';
-    var echo = opts.echo;
-    var masked = 'echo' in opts;
-    autocomplete = opts.autocomplete || autocomplete;
 
-    var fd = (process.platform === 'win32') ? 
-      process.stdin.fd :
-      fs.openSync('/dev/tty', 'rs');
+    function prompt(ask, value, opts) {
+        var insert = 0,
+            savedinsert = 0,
+            res, i, savedstr;
+        opts = opts || {};
 
-    var wasRaw = process.stdin.isRaw;
-    if (!wasRaw) { process.stdin.setRawMode(true); }
+        if (Object(ask) === ask) {
+            opts = ask;
+            ask = opts.ask;
+        }
+        else if (Object(value) === value) {
+            opts = value;
+            value = opts.value;
+        }
+        ask = ask || '';
+        var echo = opts.echo;
+        var masked = 'echo' in opts;
+        autocomplete = opts.autocomplete || autocomplete;
 
-    var buf = new Buffer(3);
-    var str = '', char, read;
-    
-    savedstr = '';
+        var fd = (process.platform === 'win32') ?
+            process.stdin.fd :
+            fs.openSync('/dev/tty', 'rs');
 
-    if (ask) {
-      process.stdout.write(ask);
-    }
+        var wasRaw = process.stdin.isRaw;
+        if (!wasRaw && process.stdin.isTTY) {
+            process.stdin.setRawMode(true);
+        }
 
-    var cycle = 0;
-    var prevComplete;
+        var buf = new Buffer(3);
+        var str = '',
+            char, read;
 
-    while (true) {
-      read = fs.readSync(fd, buf, 0, 3);
-      if (read == 3) { // received a control sequence
-        switch(buf.toString()) {
-          case '\u001b[A':  //up arrow
-            if (masked) break;
-            if (!history) break;
-            if (history.atStart()) break;
-            
-            if (history.atEnd()) {
-              savedstr = str;
-              savedinsert = insert;
+        savedstr = '';
+
+        if (ask) {
+            process.stdout.write(ask);
+        }
+
+        var cycle = 0;
+        var prevComplete;
+
+        while (true) {
+            read = fs.readSync(fd, buf, 0, 3);
+            if (read == 3) { // received a control sequence
+                switch (buf.toString()) {
+                    case '\u001b[A': //up arrow
+                        if (masked) break;
+                        if (!history) break;
+                        if (history.atStart()) break;
+
+                        if (history.atEnd()) {
+                            savedstr = str;
+                            savedinsert = insert;
+                        }
+                        str = history.prev();
+                        insert = str.length;
+                        process.stdout.write('\u001b[2K\u001b[0G' + ask + str);
+                        break;
+                    case '\u001b[B': //down arrow
+                        if (masked) break;
+                        if (!history) break;
+                        if (history.pastEnd()) break;
+
+                        if (history.atPenultimate()) {
+                            str = savedstr;
+                            insert = savedinsert;
+                            history.next();
+                        }
+                        else {
+                            str = history.next();
+                            insert = str.length;
+                        }
+                        process.stdout.write('\u001b[2K\u001b[0G' + ask + str + '\u001b[' + (insert + ask.length + 1) + 'G');
+                        break;
+                    case '\u001b[D': //left arrow
+                        if (masked) break;
+                        var before = insert;
+                        insert = (--insert < 0) ? 0 : insert;
+                        if (before - insert)
+                            process.stdout.write('\u001b[1D');
+                        break;
+                    case '\u001b[C': //right arrow
+                        if (masked) break;
+                        insert = (++insert > str.length) ? str.length : insert;
+                        process.stdout.write('\u001b[' + (insert + ask.length + 1) + 'G');
+                        break;
+                }
+                if (term.indexOf(buf[read - 1]) > -1) {
+                    fs.closeSync(fd);
+                    if (!history) break;
+                    if (!masked && str.length) history.push(str);
+                    history.reset();
+                    break;
+                }
+                continue; // any other 3 character sequence is ignored
             }
-            str = history.prev();
-            insert = str.length;
-            process.stdout.write('\u001b[2K\u001b[0G' + ask + str);
-            break;
-          case '\u001b[B':  //down arrow
-            if (masked) break;
-            if (!history) break;
-            if (history.pastEnd()) break;
-            
-            if (history.atPenultimate()) {
-              str = savedstr;
-              insert = savedinsert;
-              history.next();
-            } else {
-              str = history.next();
-              insert = str.length;
+
+            // if it is not a control character seq, assume only one character is read
+            char = buf[read - 1];
+
+            // catch a ^C and return null
+            if (char == 3) {
+                process.stdout.write('^C\n');
+                fs.closeSync(fd);
+
+                if (sigint) process.exit(130);
+
+                if (process.stdin.isTTY) {
+                    process.stdin.setRawMode(wasRaw);
+                }
+
+                return null;
             }
-            process.stdout.write('\u001b[2K\u001b[0G'+ ask + str + '\u001b['+(insert+ask.length+1)+'G');
-            break;
-          case '\u001b[D': //left arrow
-            if (masked) break;
-            var before = insert;
-            insert = (--insert < 0) ? 0 : insert;
-            if (before - insert)
-              process.stdout.write('\u001b[1D');
-            break;
-          case '\u001b[C': //right arrow
-            if (masked) break;
-            insert = (++insert > str.length) ? str.length : insert;
-            process.stdout.write('\u001b[' + (insert+ask.length+1) + 'G');
-            break;
+
+            // catch the terminating character
+            if (term.indexOf(char) > -1) {
+                fs.closeSync(fd);
+                if (!history) break;
+                if (!masked && str.length) history.push(str);
+                history.reset();
+                break;
+            }
+
+            // catch a TAB and implement autocomplete
+            if (char == 9) { // TAB
+                res = autocomplete(str);
+
+                if (str == res[0]) {
+                    res = autocomplete('');
+                }
+                else {
+                    prevComplete = res.length;
+                }
+
+                if (res.length == 0) {
+                    process.stdout.write('\t');
+                    continue;
+                }
+
+                var item = res[cycle++] || res[cycle = 0, cycle++];
+
+                if (item) {
+                    process.stdout.write('\r\u001b[K' + ask + item);
+                    str = item;
+                    insert = item.length;
+                }
+            }
+
+            if (char == 127 || (process.platform == 'win32' && char == 8)) { //backspace
+                if (!insert) continue;
+                str = str.slice(0, insert - 1) + str.slice(insert);
+                insert--;
+                process.stdout.write('\u001b[2D');
+            }
+            else {
+                if ((char < 32) || (char > 126))
+                    continue;
+                str = str.slice(0, insert) + String.fromCharCode(char) + str.slice(insert);
+                insert++;
+            };
+
+
+            if (masked) {
+                process.stdout.write('\u001b[2K\u001b[0G' + ask + Array(str.length + 1).join(echo));
+            }
+            else {
+                process.stdout.write('\u001b[s');
+                if (insert == str.length) {
+                    process.stdout.write('\u001b[2K\u001b[0G' + ask + str);
+                }
+                else {
+                    if (ask) {
+                        process.stdout.write('\u001b[2K\u001b[0G' + ask + str);
+                    }
+                    else {
+                        process.stdout.write('\u001b[2K\u001b[0G' + str + '\u001b[' + (str.length - insert) + 'D');
+                    }
+                }
+                process.stdout.write('\u001b[u');
+                process.stdout.write('\u001b[1C');
+            }
+
         }
-        continue; // any other 3 character sequence is ignored
-      }
-      
-      // if it is not a control character seq, assume only one character is read
-      char = buf[read-1];
-      
-      // catch a ^C and return null
-      if (char == 3){ 
-        process.stdout.write('^C\n');
-        fs.closeSync(fd);
-        
-        if (sigint) process.exit(130);
 
-        process.stdin.setRawMode(wasRaw);
-
-        return null;
-      }
-
-      // catch the terminating character
-      if (char == term) {
-        fs.closeSync(fd);
-        if (!history) break;
-        if (!masked && str.length) history.push(str);
-        history.reset();
-        break;
-      }
-      
-      // catch a TAB and implement autocomplete
-      if (char == 9) { // TAB
-        res = autocomplete(str);
-
-        if (str == res[0]) {
-          res = autocomplete('');
-        } else {
-          prevComplete = res.length;
+        if (process.stdin.isTTY) {
+            process.stdout.write('\n');
         }
 
-        if (res.length == 0) {
-          process.stdout.write('\t');
-          continue;
+        if (process.stdin.isTTY) {
+            process.stdin.setRawMode(wasRaw);
         }
 
-        var item = res[cycle++] || res[cycle = 0, cycle++];
-
-        if (item) {
-          process.stdout.write('\r\u001b[K' + ask + item);
-          str = item;
-          insert = item.length;
-        }
-      }
-      
-      if (char == 127 || (process.platform == 'win32' && char == 8)) { //backspace
-        if (!insert) continue;
-        str = str.slice(0, insert-1) + str.slice(insert);
-        insert--;
-        process.stdout.write('\u001b[2D');
-      } else {
-        if ((char < 32 ) || (char > 126))
-            continue;
-        str = str.slice(0, insert) + String.fromCharCode(char) + str.slice(insert);
-        insert++;
-      };
-      
-      
-      if (masked) {
-          process.stdout.write('\u001b[2K\u001b[0G' + ask + Array(str.length+1).join(echo));
-      } else {
-        process.stdout.write('\u001b[s');
-        if (insert == str.length) {
-            process.stdout.write('\u001b[2K\u001b[0G'+ ask + str);
-        } else {
-          if (ask) {
-            process.stdout.write('\u001b[2K\u001b[0G'+ ask + str);
-          } else {
-            process.stdout.write('\u001b[2K\u001b[0G'+ str + '\u001b[' + (str.length - insert) + 'D');
-          }
-        }
-        process.stdout.write('\u001b[u');
-        process.stdout.write('\u001b[1C');
-      }
-
+        return str || value || '';
     }
-    
-    process.stdout.write('\n')
-
-    process.stdin.setRawMode(wasRaw);
-    
-    return str || value || '';
-  };
 };
 
 module.exports = create;


### PR DESCRIPTION
Previously, this would error when run on some non-ttys as the `setRawMode` function wouldn't be available. I've simply wrapped all of those in `process.stdout.isTTY` property, which should prevent those errors from happening. Additionally some terminals use `\r` and others use `\n`, and others a combination of both. Now this should catch `\n` and `\r`. I haven't made any other changes I can remember. If I have I can revert them.
