### PR TITLE
Fixed an issue that would cause an error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,4 +226,4 @@ function create(config) {
   }
 };
 
-module.exports = create;
+module.exports = create();


### PR DESCRIPTION
Changed: ```module.exports = create;``` to ```module.exports = create();``` to fix,

```TypeError: Cannot create property 'autocomplete' on string 'foo ' ``` error.

Just a little thing!