### PR TITLE
Set sigint to true by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ for options, or fork it for customized behaviour.
 Returns an instance of the `prompt` function.
 Takes `config` option with the following possible properties
 
-`sigint`: Default is `false`. A ^C may be pressed during the input process to abort the text entry. If sigint it `false`, prompt returns `null`. If sigint is `true` the ^C will be handled in the traditional way: as a SIGINT signal causing process to exit with code 130.
+`sigint`: Default is `true`. A ^C may be pressed during the input process to abort the text entry. If sigint it `false`, prompt returns `null`. If sigint is `true` the ^C will be handled in the traditional way: as a SIGINT signal causing process to exit with code 130.
 
 `autocomplete`: A completer function that will be called when user enters TAB to allow for autocomplete. It takes a string as an argument an returns an array of strings that are possible matches for completion. An empty array is returned if there are no matches.
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var term = 13; // carriage return
 
 function create(config) {
 
-  config = config || {};
+  config = config || {sigint: true};
   var sigint = config.sigint;
   var autocomplete = config.autocomplete = 
     config.autocomplete || function(){return []};


### PR DESCRIPTION
Hi there,

I was using this utility, and was caught by surprise by it's behavior in response to a ^C.

I feel that the default response should be what happens traditionally. It's great to have this option, but the default should be what most people probably expect.

Thanks!