### PR TITLE
Fix Issue #25: Inappropriate Redrawn Multi-Line Asks

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ function create(config) {
 
     if (ask) {
       process.stdout.write(ask);
+      ask = ask.split(/\r?\n/).pop();
     }
 
     var cycle = 0;


### PR DESCRIPTION
### Commit Message

https://github.com/heapwolf/prompt-sync/issues/25

Prompts were causing bad user experience in situations where
the prompt contains multiple lines. This is because prompt-sync
will redraw the prompt as you type, and assumes it only takes
up one line.

The fix provided prints the whole ask string, before reassigning
ask to be only the final line of the prompt. This way, redraws
don't affect above lines.

### Testing

Wrote and executed a simple script that captures multi-line and single-line prompts.

```
const prompt = require('./prompt-sync')({sigint: true});        
                                                                
let response = prompt(`Multi-Line                               
Prompts                                                         
Are                                                             
Cool: `);                                                       
                                                                
console.log(`You Said: ${response}`);                           
                                                                
response = prompt(`Single-Line Prompts are Fine Too I Guess: `);
                                                                
console.log(`You Said: ${response}`);                           
```

And Executed:

```
[axel@arch prompt-sync]$ node test.js 
Multi-Line
Prompts
Are
Cool: yes they are
You Said: yes they are
Single-Line Prompts are Fine Too I Guess: yep
You Said: yep
```

### Potential Side-Effects
I looked over the index.js and didn't see anything concerning, but if there's an expectation that the ask variable is the *full* string provided by the user, that expectation would be broken beyond line 79.