### PR TITLE
Update dependency: solve security issue CVE-2021-3807

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "prompt-sync-history": "^1.0.1"
   },
   "dependencies": {
-    "strip-ansi": "^5.0.0"
+    "strip-ansi": "^6.0.1"
   }
 }


### PR DESCRIPTION
The dependency `strip-ansi 5.0.0` has another dependency that has a security issue.

By updating to `strip-ansi 6.0.1` the coresponding dependency is updated as well. 

Test is working fine with `6.0.1` but not `7.0.1`, so i sticked to version 6.

**Please bump the version and release a new npm version after accepting this pull request.**

# Security issue details:

![image](https://user-images.githubusercontent.com/14541962/148663383-ee2dec47-ada2-4e82-9bd8-f9af8ce7bfca.png)

[CVE-2021-3807](https://github.com/advisories/GHSA-93q8-gq69-wqmw)