### PR TITLE
Feature: Enter on Single Character

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 *sw.*
 node_modules
+.prompt_hist.txt

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ var n = prompt('How many more times? ');
 ```
 # WITH HISTORY
 
-History is an optional extra, to use simply install the history plugin. 
+History is an optional extra, to use simply install the history plugin.
 
 ```sh
 npm install --save prompt-sync-history
@@ -30,11 +30,11 @@ prompt.history.save() //save history back to file
 ```
 
 See the [prompt-sync-history](http://npm.im/prompt-sync-history) module
-for options, or fork it for customized behaviour. 
+for options, or fork it for customized behaviour.
 
 # API
 
-## `require('prompt-sync')(config) => prompt` 
+## `require('prompt-sync')(config) => prompt`
 
 Returns an instance of the `prompt` function.
 Takes `config` option with the following possible properties
@@ -47,10 +47,12 @@ Takes `config` option with the following possible properties
 
 `history`: Takes an object that supplies a "history interface", see [prompt-sync-history](http://npm.im/prompt-sync-history) for an example.
 
+`submitOnCharacter`: Entering any single character results in submission (auto enter). Supports a use case like 'press **w** to see more options'.
+
 ## `prompt(ask, value, opts)`
 
 `ask` is the label of the prompt, `value` is the default value
-in absence of a response. 
+in absence of a response.
 
 The `opts` argument can also be in the first or second parameter position.
 
@@ -58,7 +60,7 @@ Opts can have the following properties
 
 `echo`: Default is `'*'`. If set the password will be masked with the specified character. For hidden input, set echo to `''` (or use `prompt.hide`).
 
-`autocomplete`: Overrides the instance `autocomplete` function to allow for custom 
+`autocomplete`: Overrides the instance `autocomplete` function to allow for custom
 autocompletion of a particular prompt.
 
 `value`: Same as the `value` parameter, the default value for the prompt. If `opts`
@@ -68,7 +70,7 @@ is in the third position, this property will *not* overwrite the `value` paramet
 
 ## `prompt.hide(ask)`
 
-Convenience method for creating a standard hidden password prompt, 
+Convenience method for creating a standard hidden password prompt,
 this is the same as `prompt(ask, {echo: ''})`
 
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var term = 13; // carriage return
  * @returns {Function} prompt function
  */
 
- // for ANSI escape codes reference see https://en.wikipedia.org/wiki/ANSI_escape_code
+// for ANSI escape codes reference see https://en.wikipedia.org/wiki/ANSI_escape_code
 
 function create(config) {
 
@@ -24,6 +24,7 @@ function create(config) {
   var autocomplete = config.autocomplete =
     config.autocomplete || function(){return []};
   var history = config.history;
+  var submitOnCharacter = config.submitOnCharacter || false;
   prompt.history = history || {save: function(){}};
   prompt.hide = function (ask) { return prompt(ask, {echo: ''}) };
 
@@ -201,10 +202,19 @@ function create(config) {
         process.stdout.write('\u001b[2D');
       } else {
         if ((character < 32 ) || (character > 126))
-            continue;
+          continue;
         str = str.slice(0, insert) + String.fromCharCode(character) + str.slice(insert);
         insert++;
       };
+
+      // user wants to submit on single character entry
+      if (submitOnCharacter) {
+        fs.closeSync(fd);
+        if (!history) break;
+        if (!masked && str.length) history.push(str);
+        history.reset();
+        break;
+      }
 
       promptPrint(masked, ask, echo, str, insert);
 

--- a/test.js
+++ b/test.js
@@ -22,7 +22,14 @@ var autocompleteTest = prompt('custom autocomplete: ', {
 
 prompt.history.save();
 
-console.log('\nName: %s\nPassword *: %s\nHidden password: %s\nAnother Hidden password: %s', name, pw, pwb, pwc);
+var prompt2 = require('./')({
+  sigint: false,
+  submitOnCharacter: true
+});
+
+var submitOnCharacter = prompt2('enter single character: ', { submitOnCharacter: true });
+
+console.log('\nName: %s\nPassword *: %s\nHidden password: %s\nAnother Hidden password: %s\nauto character:%s', name, pw, pwb, pwc, submitOnCharacter);
 console.log('autocomplete2: ', autocompleteTest);
 
 function complete(commands) {


### PR DESCRIPTION
prompt-sync now supports entering a single character. On typing a single character, prompt-sync will exit: returning the single character. Usage example: Press **w** to see more options...

Other updates:

* a bit of formatting (auto format)
* now ignore .prompt_hist.txt