### PR TITLE
Fix for handling multiple tab autocomplete attempts

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,6 +195,8 @@ function create(config) {
       } else {
         // user entered anything other than TAB; reset from last use of autocomplete 
         autoCompleteSearchTerm = undefined; 
+        // reset cycle - next time user hits tab might yield a different result list 
+        cycle = 0;
       }
 
       if (character == 127 || (process.platform == 'win32' && character == 8)) { //backspace

--- a/index.js
+++ b/index.js
@@ -79,7 +79,6 @@ function create(config) {
     }
 
     var cycle = 0;
-    var prevComplete;
 
     while (true) {
       read = fs.readSync(fd, buf, 0, 3);
@@ -176,9 +175,7 @@ function create(config) {
 
         if (str == res[0]) {
           res = autocomplete('');
-        } else {
-          prevComplete = res.length;
-        }
+        } 
 
         if (res.length == 0) {
           process.stdout.write('\t');

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var fs = require('fs');
 var stripAnsi = require('strip-ansi');
 var term = 13; // carriage return
 
+
 /**
  * create -- sync function for reading user input from stdin
  * @param   {Object} config {
@@ -71,6 +72,7 @@ function create(config) {
 
     var buf = Buffer.alloc(3);
     var str = '', character, read;
+    var autoCompleteSearchTerm;
 
     savedstr = '';
 
@@ -171,11 +173,11 @@ function create(config) {
 
       // catch a TAB and implement autocomplete
       if (character == 9) { // TAB
-        res = autocomplete(str);
+        // first TAB hit, save off original input 
+        if(autoCompleteSearchTerm === undefined)
+          autoCompleteSearchTerm = str;
 
-        if (str == res[0]) {
-          res = autocomplete('');
-        } 
+        res = autocomplete(autoCompleteSearchTerm);
 
         if (res.length == 0) {
           process.stdout.write('\t');
@@ -187,8 +189,12 @@ function create(config) {
         if (item) {
           process.stdout.write('\r\u001b[K' + ask + item);
           str = item;
+
           insert = item.length;
         }
+      } else {
+        // user entered anything other than TAB; reset from last use of autocomplete 
+        autoCompleteSearchTerm = undefined; 
       }
 
       if (character == 127 || (process.platform == 'win32' && character == 8)) { //backspace


### PR DESCRIPTION
## What is this attempting to fix?
Prior to this PR, a user's input was taken into account only for the first autocompletion pass through; after which prompt-sync would fall back to cycling through the entire possible data set provided by the user, regardless of whether the initial search string yielded multiple possible autocomplete results.

Additionally, any subsequent autocomplete attempts would yield results from anywhere within the new result list, not the start. 

## How does this fix the problem?

This PR splits the responsibilities of the autocomplete search string and the main output string between two variables. 
`autoCompleteSearchTerm` allows users to cycle through the results of the current search, while `str` allows current selection and terminal output to stay up-to-date as it did before. 

Hitting any other key after the tab would clear the current search state. 

## Testing / Example Case

**Simple demo program to demonstrate the fix:**

```
const fullList = [
  "Apple",
  "Broil",
  "Cup",
  "Baseball",
  "Danger",
  "Cast",
  "Dork",
  "Create",
  "Ardvark",
  "Balloon",
  "Avocado",
  "Dog",
  "Aromatic",
  "Destiny",
  "Apperant"
];

const complete = (choices) => (str) =>
  choices.filter(
    (choice) => choice.toLowerCase().indexOf(str.toLowerCase()) === 0
  );

const prompt = require(".")({
  autocomplete: complete(fullList),
});

const resp = prompt("Enter a string then press TAB: ");

console.log(`You entered: ${resp}`);
```

In either version, running the program and entering "a", followed by TAB would yield the string: "Apple". 

Prior to the fix, subsequent TAB inputs would yield the following results: 

```
"Broil"
"Cup"
"Baseball"
"Danger"
etc...
```

After the fix, subsequent tab inputs yield all a-strings: 

```
"Apperant"
"Apple"
"Ardvark"
"Aromatic"
"Avocado"
```

## Demo
​
**Before**

![Kapture 2022-08-15 at 21 56 09](https://user-images.githubusercontent.com/6632738/184782214-a17b7090-08a4-48b2-91ed-b7afe78906cc.gif)

**After**

![Kapture 2022-08-15 at 21 57 51](https://user-images.githubusercontent.com/6632738/184782470-cc1af1a0-492a-474f-be64-b8814751a15f.gif)

