### PR TITLE
solution to repeated prompt on each keystroke

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,16 @@ function create(config) {
     savedstr = '';
 
     if (ask) {
-      process.stdout.write(ask);
+      if (ask.includes('\n')) {
+        let parts = ask.split('\n')
+        console.log(parts)
+        parts.forEach(part => {
+          process.stdout.write(part)
+        });
+        ask = ask.replaceAll('\n', '')
+      } else {
+        process.stdout.write(ask);
+      }
     }
 
     var cycle = 0;


### PR DESCRIPTION
Hacky fix for weird behaviour when calling `prompt('some text\n');`. I don't understand how the `prompt()` function works entirely, but if the `ask` variable includes a newline character, weird behaviour can occur, with each keystroke the prompt is printed again.

Reproduce:
```
const prompt = require('prompt-sync')();
const in = prompt('this is a test: \n');
console.log(in);
```
With this code, each keystroke will cause the `prompt()` text to be printed again, until a return keystroke is sent. This patch checks for `\n` within the `ask` variable inside the `prompt()` function prints it separately, then strips it from the string.

Before change:
<img width="293" alt="Screenshot 2023-05-31 at 00 41 20" src="https://github.com/heapwolf/prompt-sync/assets/5632446/df8f0223-ee12-4524-8c31-4c77604a734d">


After change:
<img width="302" alt="Screenshot 2023-05-31 at 00 41 59" src="https://github.com/heapwolf/prompt-sync/assets/5632446/276e4d54-6fae-44ab-810f-49ba575e68d6">
